### PR TITLE
Fix: make entrypoint.sh and action.yaml work together

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,10 +21,10 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - -c ${{ inputs.config }}
-    - -d ${{ inputs.dir }}
-    - -b ${{ inputs.board }}
-    - -e ${{ inputs.schema }}
+    -  -c ${{ inputs.config }}
+    -  -d ${{ inputs.dir }}
+    -  -b ${{ inputs.board }}
+    -  -e ${{ inputs.schema }}
 branding:
   icon: 'cpu'
   color: 'green'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -182,5 +182,11 @@ function main {
     run
 }
 
+# Removes quotes
+args=$(xargs <<<"$@")
+
+# Arguments as an array
+IFS=' ' read -a args <<< "$args"
+
 # Run main
-main "$@"
+main "${args[@]}"


### PR DESCRIPTION
Hi

in order to make `kicad-export` work with the arguments passed by `action.yaml` (that is not an array), some processing is needed.

With this patch we will be able to enable tests and also to use this as a github action in develop.

Thanks